### PR TITLE
resolve namespace bug and update client schema

### DIFF
--- a/oauth2/controllers/AuthorizeController.php
+++ b/oauth2/controllers/AuthorizeController.php
@@ -5,7 +5,7 @@ namespace longthanhtran\oauth2\controllers;
 
 use app\models\User;
 use longthanhtran\oauth2\Module;
-use League\oauth2\Server\Exception\OAuthServerException;
+use League\OAuth2\Server\Exception\OAuthServerException;
 use Yii;
 
 class AuthorizeController extends BaseController

--- a/oauth2/controllers/TokenController.php
+++ b/oauth2/controllers/TokenController.php
@@ -3,7 +3,7 @@
 namespace longthanhtran\oauth2\controllers;
 
 use longthanhtran\oauth2\Module;
-use League\oauth2\Server\Exception\OAuthServerException;
+use League\OAuth2\Server\Exception\OAuthServerException;
 use Yii;
 use yii\helpers\Json;
 

--- a/oauth2/core/models/AccessToken.php
+++ b/oauth2/core/models/AccessToken.php
@@ -2,11 +2,11 @@
 
 namespace longthanhtran\oauth2\core\models;
 
-use League\oauth2\Server\Entities\AccessTokenEntityInterface;
-use League\oauth2\Server\Entities\ClientEntityInterface;
-use League\oauth2\Server\Entities\Traits\AccessTokenTrait;
-use League\oauth2\Server\Entities\Traits\EntityTrait;
-use League\oauth2\Server\Entities\Traits\TokenEntityTrait;
+use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
+use League\OAuth2\Server\Entities\ClientEntityInterface;
+use League\OAuth2\Server\Entities\Traits\AccessTokenTrait;
+use League\OAuth2\Server\Entities\Traits\EntityTrait;
+use League\OAuth2\Server\Entities\Traits\TokenEntityTrait;
 
 class AccessToken implements AccessTokenEntityInterface
 {

--- a/oauth2/core/models/AuthCode.php
+++ b/oauth2/core/models/AuthCode.php
@@ -2,10 +2,10 @@
 
 namespace longthanhtran\oauth2\core\models;
 
-use League\oauth2\Server\Entities\AuthCodeEntityInterface;
-use League\oauth2\Server\Entities\Traits\AuthCodeTrait;
-use League\oauth2\Server\Entities\Traits\EntityTrait;
-use League\oauth2\Server\Entities\Traits\TokenEntityTrait;
+use League\OAuth2\Server\Entities\AuthCodeEntityInterface;
+use League\OAuth2\Server\Entities\Traits\AuthCodeTrait;
+use League\OAuth2\Server\Entities\Traits\EntityTrait;
+use League\OAuth2\Server\Entities\Traits\TokenEntityTrait;
 
 class AuthCode implements AuthCodeEntityInterface
 {

--- a/oauth2/core/models/Client.php
+++ b/oauth2/core/models/Client.php
@@ -2,8 +2,8 @@
 
 namespace longthanhtran\oauth2\core\models;
 
-use League\oauth2\Server\Entities\ClientEntityInterface;
-use League\oauth2\Server\Entities\Traits\ClientTrait;
+use League\OAuth2\Server\Entities\ClientEntityInterface;
+use League\OAuth2\Server\Entities\Traits\ClientTrait;
 
 
 class Client implements ClientEntityInterface

--- a/oauth2/core/models/RefreshToken.php
+++ b/oauth2/core/models/RefreshToken.php
@@ -2,9 +2,9 @@
 
 namespace longthanhtran\oauth2\core\models;
 
-use League\oauth2\Server\Entities\RefreshTokenEntityInterface;
-use League\oauth2\Server\Entities\Traits\EntityTrait;
-use League\oauth2\Server\Entities\Traits\RefreshTokenTrait;
+use League\OAuth2\Server\Entities\RefreshTokenEntityInterface;
+use League\OAuth2\Server\Entities\Traits\EntityTrait;
+use League\OAuth2\Server\Entities\Traits\RefreshTokenTrait;
 
 
 class RefreshToken implements RefreshTokenEntityInterface

--- a/oauth2/core/models/Scope.php
+++ b/oauth2/core/models/Scope.php
@@ -2,8 +2,8 @@
 
 namespace longthanhtran\oauth2\core\models;
 
-use League\oauth2\Server\Entities\ScopeEntityInterface;
-use League\oauth2\Server\Entities\Traits\EntityTrait;
+use League\OAuth2\Server\Entities\ScopeEntityInterface;
+use League\OAuth2\Server\Entities\Traits\EntityTrait;
 
 class Scope implements ScopeEntityInterface
 {

--- a/oauth2/migrations/m210830_041002_create_clients_table.php
+++ b/oauth2/migrations/m210830_041002_create_clients_table.php
@@ -14,9 +14,10 @@ class m210830_041002_create_clients_table extends Migration
     {
         $this->createTable('{{%clients}}', [
             'id' => $this->bigPrimaryKey()->unsigned(),
-            'user_id' => $this->bigInteger()->unsigned()->null()->unique(),
+            'user_id' => $this->bigInteger()->unsigned()->null(),
             'name' => $this->string(),
             'secret' => $this->string(100)->null(),
+            'identifier' => $this->string(255)->unique(),
             'provider' => $this->string()->null(),
             'redirect' => $this->string(),
             'personal_access_client' => $this->boolean(),

--- a/oauth2/models/Client.php
+++ b/oauth2/models/Client.php
@@ -45,7 +45,7 @@ class Client extends ActiveRecord
 
     public function getUser()
     {
-        $this->hasOne(User::class, ['id' => 'user_id']);
+        return $this->hasOne(User::class, ['id' => 'user_id']);
     }
 
 }

--- a/oauth2/services/TokenService.php
+++ b/oauth2/services/TokenService.php
@@ -5,7 +5,7 @@ namespace longthanhtran\oauth2\services;
 use longthanhtran\oauth2\core\repositories\FormatScopesForStorage;
 use longthanhtran\oauth2\models\Client;
 use longthanhtran\oauth2\models\Token;
-use League\oauth2\Server\Entities\AccessTokenEntityInterface;
+use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
 
 class TokenService
 {


### PR DESCRIPTION
Previous commit came with namespace bug on League package usage.

Client table schema now no long tie to one user and has identifier for each client.